### PR TITLE
add redeem keys context menu items

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -2,7 +2,10 @@
 
 // context menu
 {
+    // remove all existing context menus
+    chrome.contextMenus.removeAll();
 
+    // create new context menu items
 
     // elecord
     chrome.contextMenus.create({

--- a/background/background.js
+++ b/background/background.js
@@ -1,41 +1,147 @@
-// Parent context menu
-chrome.contextMenus.create({
-    id: "menu-elecord",
-    title: "Elecord",
-    contexts: ["selection"]
-});
+// background script
 
-// Submenus 1
-chrome.contextMenus.create({
-    id: "menu-search",
-    title: "🔎 Search '%s'",
-    contexts: ["selection"],
-    parentId: "menu-elecord"
-});
+// context menu
+{
 
-// Submenus 2
-chrome.contextMenus.create({
-    id: "menu-ggdeals",
-    title: "🟣 gg.deals",
-    contexts: ["selection"],
-    parentId: "menu-search"
-});
 
-chrome.contextMenus.create({
-    id: "menu-steam",
-    title: "🔵 Steam",
-    contexts: ["selection"],
-    parentId: "menu-search"
-});
+    // elecord
+    chrome.contextMenus.create({
+        id: "menu-elecord",
+        title: "Elecord",
+        contexts: ["all"]
+    });
 
-// Event listeners
+    {
+        // search
+        chrome.contextMenus.create({
+            id: "menu-search",
+            title: "🔎 Search '%s'",
+            contexts: ["selection"],
+            parentId: "menu-elecord"
+        });
+
+        {
+            // gg.deals
+            chrome.contextMenus.create({
+                id: "menu-search-ggdeals",
+                title: "🔥 gg.deals",
+                contexts: ["selection"],
+                parentId: "menu-search"
+            });
+
+            // steam
+            chrome.contextMenus.create({
+                id: "menu-search-steam",
+                title: "🔵 Steam",
+                contexts: ["selection"],
+                parentId: "menu-search"
+            });
+        };
+
+        // redeem
+        chrome.contextMenus.create({
+            id: "menu-redeem",
+            title: "🔑 Redeem %s",
+            contexts: ["all"],
+            parentId: "menu-elecord"
+        });
+
+        {
+            // steam
+            chrome.contextMenus.create({
+                id: "menu-redeem-steam",
+                title: "🔵 Steam",
+                contexts: ["all"],
+                parentId: "menu-redeem"
+            });
+
+            // gog
+            chrome.contextMenus.create({
+                id: "menu-redeem-gog",
+                title: "🟣 GOG",
+                contexts: ["all"],
+                parentId: "menu-redeem"
+            });
+
+            // epic
+            chrome.contextMenus.create({
+                id: "menu-redeem-epic",
+                title: "⚪️ Epic",
+                contexts: ["all"],
+                parentId: "menu-redeem"
+            });
+
+            // // xbox
+            // chrome.contextMenus.create({
+            //     id: "menu-redeem-xbox",
+            //     title: "🟢 Xbox",
+            //     contexts: ["all"],
+            //     parentId: "menu-redeem"
+            // });
+
+            // // ea
+            // chrome.contextMenus.create({
+            //     id: "menu-redeem-ea",
+            //     title: "🔴 EA",
+            //     contexts: ["all"],
+            //     parentId: "menu-redeem"
+            // });
+
+            // // ubisoft
+            // chrome.contextMenus.create({
+            //     id: "menu-redeem-ubisoft",
+            //     title: "🟡 Ubi",
+            //     contexts: ["all"],
+            //     parentId: "menu-redeem"
+            // });
+        };
+
+    };
+};
+
+
+// event listeners
 chrome.contextMenus.onClicked.addListener((info, tab) => {
-    if (info.menuItemId === "menu-ggdeals") {
-        let url = `https://gg.deals/games/?view=list&title=${encodeURIComponent(info.selectionText)}`;
-        chrome.tabs.create({ url: url });
+
+    switch (info.menuItemId) {
+        // search
+        case "menu-search-ggdeals":
+            encodeURL('https://gg.deals/games/?view=list&title=', info.selectionText);
+            break;
+        case "menu-search-steam":
+            encodeURL('https://store.steampowered.com/search/?term=', info.selectionText);
+            break;
+
+        // redeem
+        case "menu-redeem-steam":
+            encodeURL('https://store.steampowered.com/account/registerkey?key=', info.selectionText);
+            break;
+        case "menu-redeem-gog":
+            encodeURL('https://www.gog.com/en/redeem/', info.selectionText);
+            break;
+        case "menu-redeem-epic":
+            encodeURL('https://store.epicgames.com/en-US/redeem?code=', info.selectionText);
+            break;
+    }
+
+    /**
+     * Encodes a given URL with an optional selection text and
+     * creates a new tab with the resulting URL.
+     *
+     * @param {string} url The base URL to use.
+     * @param {string} [selection] Optional selection text to encode and append.
+     */
+    function encodeURL(url, selection) {
+
+        // encode url with or without selection
+        let urlEncoded = url;
+        if (selection) {
+            urlEncoded = url + encodeURIComponent(selection);
+        }
+
+        // create new tab
+        chrome.tabs.create({ url: urlEncoded });
+
     };
-    if (info.menuItemId === "menu-steam") {
-        let url = `https://store.steampowered.com/search/?term=${encodeURIComponent(info.selectionText)}`;
-        chrome.tabs.create({ url: url });
-    };
+
 });

--- a/options/options.js
+++ b/options/options.js
@@ -28,13 +28,13 @@ function restoreOptions() {
 
 // Function to update the context menus based on the options
 function updateContextMenus(options) {
-    // Hide or show "menu-ggdeals" context menu
-    chrome.contextMenus.update("menu-ggdeals", {
+    // Hide or show "menu-search-ggdeals" context menu
+    chrome.contextMenus.update("menu-search-ggdeals", {
         visible: options.optionGGDeals
     });
 
-    // Hide or show "menu-steam" context menu
-    chrome.contextMenus.update("menu-steam", {
+    // Hide or show "menu-search-steam" context menu
+    chrome.contextMenus.update("menu-search-steam", {
         visible: options.optionSteam
     });
 


### PR DESCRIPTION
Users can now directly visit game key redemption pages for Steam, GOG and Epic web stores via the context menu. If used when a key is selected as text (e.g. you want to redeem a free key from your Twitch Prime page). Then key will automatically be populated when visiting the store redemption page.