### PR TITLE
Firefox compatibility

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -44,7 +44,7 @@
         // redeem
         chrome.contextMenus.create({
             id: "menu-redeem",
-            title: "🔑 Redeem %s",
+            title: "🔑 Redeem",
             contexts: ["all"],
             parentId: "menu-elecord"
         });

--- a/manifest.json
+++ b/manifest.json
@@ -12,11 +12,9 @@
         "*://*.steampowered.com/*",
         "*://www.pcgamer.com/*"
     ],
-    "action": {
-        "default_title": "Elecord",
-        "default_icon": {
-            "128": "icon.png"
-        }
+    "background": {
+        "service_worker": "background/background.js",
+        "scripts": ["background/background.js"]
     },
     "content_scripts": [
         {
@@ -58,14 +56,17 @@
             "matches": ["<all_urls>"]
         }
     ],
-    "background": {
-        "service_worker": "background/background.js"
-    },
-    "icons": {
-        "128": "icon.png"
-    },
     "options_ui": {
         "page": "options/options.html",
         "open_in_tab": false
+    },
+    "action": {
+        "default_title": "Elecord",
+        "default_icon": {
+            "128": "icon.png"
+        }
+    },
+    "icons": {
+        "128": "icon.png"
     }
 }

--- a/scripts/steam-app-content.js
+++ b/scripts/steam-app-content.js
@@ -2,6 +2,9 @@
 
 const componentsLocation = '/components/steam/app/';
 
+let rightcol = {
+    location: "div.rightcol.game_meta_data",
+}
 let feature = {
     element: document.querySelectorAll('div.label')
 };
@@ -38,7 +41,11 @@ if (document.querySelector('div.breadcrumbs div.blockbg a').textContent === "All
 
     // key details box
     {
-        addElement('ele-details.html', 'div.rightcol.game_meta_data', []);
+        // modify existing rightcol with flex
+        rightcol.element = document.querySelector(rightcol.location)
+        rightcol.element.classList.add('e-rightcol');
+        // add key details to rightcol
+        addElement('ele-details.html', rightcol.location, []);
         WriteLine('Created key details box');
     };
 

--- a/styles/steam-app-styles.css
+++ b/styles/steam-app-styles.css
@@ -4,6 +4,12 @@
     --steam-blue: #30485e;
 }
 
+/* right column */
+.e-rightcol {
+    display: flex;
+    flex-direction: column;
+}
+
 /* key details box */
 .e-details {
     order: -10;


### PR DESCRIPTION
Updated the extension for compatibility with Firefox. Fixing one display issue with the Steam key details feature and updated the extension manifest file.

While the new manifest.json works with both browsers, a warning is now displayed. Ideally remove the following on deployment:
- For Firefox, remove: `"service_worker": "background/background.js"`
- For Chrome, remove: `"scripts": ["background/background.js"]`

See https://github.com/w3c/webextensions/issues/282