### PR TITLE
Add ProtonDB search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Collection of handy tools and tweaks for gamers across the web
 - [x] Context menu search for games
     - gg.deals
     - Steam
+    - ProtonDB
 - [x] Context menu redeem game keys
     - Steam
     - GOG

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,6 +19,7 @@ const optionKeys = [
     // worker.js
     'opt-search-ggdeals',
     'opt-search-steam',
+    'opt-search-protondb',
     'opt-redeem-steam',
     'opt-redeem-gog',
     'opt-redeem-epic',

--- a/scripts/worker.js
+++ b/scripts/worker.js
@@ -97,7 +97,7 @@ try {
             // submenus
             {
                 // search
-                if (options['opt-search-ggdeals'] || options['opt-search-steam']) {
+                if (options['opt-search-ggdeals'] || options['opt-search-steam'] || options['opt-search-protondb']) {
                     chrome.contextMenus.create({
                         id: "menu-search",
                         title: "🔎 Search '%s'",
@@ -118,6 +118,15 @@ try {
                         chrome.contextMenus.create({
                             id: "menu-search-steam",
                             title: "🔵 Steam",
+                            contexts: ["selection"],
+                            parentId: "menu-search"
+                        });
+                    }
+                    // protondb
+                    if (options['opt-search-protondb']) {
+                        chrome.contextMenus.create({
+                            id: "menu-search-protondb",
+                            title: "🪐 ProtonDB",
                             contexts: ["selection"],
                             parentId: "menu-search"
                         });
@@ -203,6 +212,9 @@ try {
                 break;
             case "menu-search-steam":
                 encodeURL('https://store.steampowered.com/search/?term=', info.selectionText);
+                break;
+            case "menu-search-protondb":
+                encodeURL('https://www.protondb.com/search?q=', info.selectionText);
                 break;
 
             // redeem

--- a/views/options.html
+++ b/views/options.html
@@ -60,6 +60,11 @@
                     <input type="checkbox" id="opt-search-steam" class="e-option__checkbox">
                     <label for="opt-search-steam" class="e-option__label">Show 'Search Steam'</label>
                 </div>
+
+                <div class="e-option">
+                    <input type="checkbox" id="opt-search-protondb" class="e-option__checkbox">
+                    <label for="opt-search-protondb" class="e-option__label">Show 'Search ProtonDB'</label>
+                </div>
             </div>
 
             <div class="e-container__section__sub-section">


### PR DESCRIPTION
Similar to gg.deals and Steam context menu search options, users can now also search [protondb.com](https://www.protondb.com/).