### PR TITLE
Remove extension's host permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,10 +9,6 @@
         "contextMenus",
         "storage"
     ],
-    "host_permissions": [
-        "*://*.steampowered.com/*",
-        "*://*.pcgamer.com/*"
-    ],
     "browser_specific_settings": {
         "gecko": {
             "id": "{e42a96bd-c8dc-4cd9-b7ea-b5c48b02b3cf}",


### PR DESCRIPTION
These manifest permissions aren't required for the extension to function.